### PR TITLE
Add container class attribute to all STAC classes

### DIFF
--- a/intake_stac/catalog.py
+++ b/intake_stac/catalog.py
@@ -13,6 +13,7 @@ NULL_TYPE = 'null'
 
 class AbstractStacCatalog(Catalog):
 
+    container = 'python'
     version = __version__
     partition_access = False
 


### PR DESCRIPTION
Putting this up for discussion with @martindurant. I believe this change will make the tests fail but I'm not sure why. 

I'm following https://intake.readthedocs.io/en/latest/making-plugins.html and expected this particular change to be closer to a no-op, rather than something that changes behavior significantly. I'd love to understand what is happening here. 

To save time, this is the error I end up getting (only failing in one test):

```python-traceback
stac_collection_obj = sentinel-2-l1c

    def test_cat_from_collection(stac_collection_obj):
        cat = StacCollection(stac_collection_obj)
        assert 'L1C_T53MNQ_A017245_20181011T011722' in cat
>       assert 'B05' in cat.L1C_T53MNQ_A017245_20181011T011722
E       TypeError: argument of type 'LocalCatalogEntry' is not iterable

intake_stac/tests/test_catalog.py:94: TypeError
```
